### PR TITLE
Handle approved column in product catalog

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,7 +183,7 @@
 
     // Acceptable column names for each logical field
     const PRODUCT_COLS={
-      status:    ['Status','Approval Status','status','approved'],
+      status:    ['Status','Approval Status','status'],
       slug:      ['Slug','Product ID','product_id','slug','ID','id'],
       name:      ['Product Name','Name','Item Name','title'],
       category:  ['Category','Categories','category'],
@@ -197,7 +197,8 @@
       imprint:   ['Imprint Method','Imprint','Decoration','imprint','decoration'],
       lead:      ['Lead Time (days)','Lead Time','Lead Days','lead_time_days','lead_time'],
       minQty:    ['Min Qty','Minimum Qty','Minimum Quantity','min_qty','minimum_quantity'],
-      tags:      ['Tags','Keywords','Search Tags','tags','keywords']
+      tags:      ['Tags','Keywords','Search Tags','tags','keywords'],
+      approved:  ['Approved','approved']
     };
     const VARIANT_COLS={
       productId: ['Product ID','product_id','Slug','slug','ID','id'],
@@ -232,8 +233,9 @@
       }, {});
 
       const statuses = products.map(p=>pick(p, PRODUCT_COLS.status));
+      const approvals = products.map(p=>pick(p, PRODUCT_COLS.approved));
       const catalog = products
-        .filter((p,i) => norm(statuses[i])==='approved')
+        .filter((p,i) => norm(statuses[i])==='approved' || norm(approvals[i])==='true')
         .map(p=>{
           const id=normId(pick(p, PRODUCT_COLS.slug));
           const name=pick(p, PRODUCT_COLS.name);
@@ -262,7 +264,7 @@
         });
 
       if(!catalog.length){
-        const msg = (products.length && statuses.some(s=>String(s).trim()))
+        const msg = (products.length && (statuses.some(s=>String(s).trim()) || approvals.some(a=>String(a).trim())))
           ? 'No approved products found.'
           : 'Check published CSV headers—no matching aliases found.';
         document.getElementById('cards').innerHTML =


### PR DESCRIPTION
## Summary
- differentiate approval status from approval flag by adding `approved` column aliases
- show products when either `status` is `approved` or `approved` field is `true`
- warn appropriately when no approved products are found

## Testing
- `npm test` (fails: Missing script: "test")
- `python` script to ensure filter includes approved rows and excludes unapproved rows

------
https://chatgpt.com/codex/tasks/task_b_68bf16da827c832ea79fc6ab72b9af6a