### PR TITLE
feat: add category sections and product detail view

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,19 +55,22 @@
 
     /* Cards */
     .cards{display:grid;gap:16px;grid-template-columns:repeat(auto-fill,minmax(260px,1fr))}
-    .card{background:#fff;border:1px solid #eee;border-radius:var(--radius);box-shadow:0 1px 2px rgba(0,0,0,.06);display:flex;flex-direction:column;overflow:hidden}
+    .card{background:#fff;border:1px solid #eee;border-radius:var(--radius);box-shadow:0 1px 2px rgba(0,0,0,.06);display:flex;flex-direction:column;overflow:hidden;text-decoration:none;color:inherit}
     .thumb{aspect-ratio:4/3;background:#fafafa;display:flex;align-items:center;justify-content:center}
     .thumb img{width:100%;height:100%;object-fit:cover}
     .meta{padding:12px 14px;display:grid;gap:8px}
     .name{font-family:Montserrat,system-ui;font-weight:700}
-    .sub{color:#555;font-size:13px}
     .price{font-family:Montserrat,system-ui;font-weight:700}
-    .chip{display:inline-block;padding:2px 8px;border-radius:999px;background:#fff3d6;border:1px solid rgba(244,163,0,.35);color:#7a5200;font-size:12px;margin-right:6px}
     .sizes{border-top:1px dashed #eee;padding:10px 14px;font-size:13px;line-height:1.6;color:#333}
     .sizes dt{font-family:Montserrat,system-ui;font-weight:700}
     .actions{display:flex;gap:8px;padding:12px 14px 14px}
     .btn{border:1px solid var(--brand);background:var(--brand);color:#fff;border-radius:10px;padding:8px 10px;font-size:14px;text-decoration:none;cursor:pointer}
     .btn:hover{background:var(--brand-dark);border-color:var(--brand-dark)}
+    #detail .layout{display:grid;gap:24px}
+    @media(min-width:800px){#detail .layout{grid-template-columns:1fr 1fr}}
+    #detail img{max-width:100%;height:auto}
+    #detail .gallery{display:flex;gap:8px;flex-wrap:wrap;margin-top:10px}
+    #detail .gallery img{width:120px;height:120px;object-fit:cover;border:1px solid #eee;border-radius:var(--radius)}
 
     /* Footer */
     footer{border-top:1px solid #eee;background:#fff}
@@ -127,9 +130,15 @@
   <main>
     <div class="wrap">
       <div id="count" class="muted" style="padding:4px 2px 12px"></div>
-      <div id="cards" class="cards"></div>
+      <div id="cards"></div>
     </div>
   </main>
+
+  <section id="detail" style="display:none;">
+    <div class="wrap">
+      <div id="detail-content"></div>
+    </div>
+  </section>
 
   <!-- Footer -->
   <footer>
@@ -191,17 +200,10 @@
       slug:      ['Slug','Product ID','product_id','slug','ID','id'],
       name:      ['Product Name','Name','Item Name','title'],
       category:  ['Category','Categories','category'],
-      vendor:    ['Vendor','Supplier','vendor','supplier'],
-      vendorSku: ['Vendor SKU','SKU','Supplier SKU','vendor_sku','sku'],
       preview:   ['Preview Link','3D Preview URL','Preview URL','model_3d_url','Model 3D URL'],
       thumb:     ['Thumbnail URL','Image','Image URL','Primary Image','primary_image_url','image_url','primary image'],
-      setup:     ['Setup Charge (USD)','Setup','Setup Charge','setup_charge_usd','setup_charge'],
-      repeat:    ['Repeat Setup (USD)','Repeat Setup','Repeat','repeat_setup_usd','repeat_setup'],
-      setupNotes:['Setup Notes','Imprint Notes','Notes','setup_notes','imprint_notes'],
-      imprint:   ['Imprint Method','Imprint','Decoration','imprint','decoration'],
-      lead:      ['Lead Time (days)','Lead Time','Lead Days','lead_time_days','lead_time'],
-      minQty:    ['Min Qty','Minimum Qty','Minimum Quantity','min_qty','minimum_quantity'],
-      tags:      ['Tags','Keywords','Search Tags','tags','keywords'],
+      description:['Description','Product Description','description'],
+      gallery:   ['Gallery URLs','Gallery','gallery_urls','gallery'],
       approved:  ['Approved','approved']
     };
     const VARIANT_COLS={
@@ -249,19 +251,13 @@
           const maxPrice=nums.length?Math.max(...nums):null;
           vs.sort((a,b)=>{const na=toNum(a.price),nb=toNum(b.price); if(na!=null&&nb!=null) return na-nb; if(na!=null) return -1; if(nb!=null) return 1; return (a.size||'').localeCompare(b.size||'');});
           return {
+            id,
             name,
             category:pick(p, PRODUCT_COLS.category),
-            vendor:pick(p, PRODUCT_COLS.vendor),
-            vendorSku:pick(p, PRODUCT_COLS.vendorSku),
             preview:pick(p, PRODUCT_COLS.preview),
             thumb:pick(p, PRODUCT_COLS.thumb),
-            setup:pick(p, PRODUCT_COLS.setup),
-            repeat:pick(p, PRODUCT_COLS.repeat),
-            setupNotes:pick(p, PRODUCT_COLS.setupNotes),
-            imprint:pick(p, PRODUCT_COLS.imprint),
-            lead:pick(p, PRODUCT_COLS.lead),
-            minQty:pick(p, PRODUCT_COLS.minQty),
-            tags:pick(p, PRODUCT_COLS.tags),
+            description:pick(p, PRODUCT_COLS.description),
+            gallery:pick(p, PRODUCT_COLS.gallery),
             variants:vs,
             minPrice,maxPrice
           };
@@ -277,43 +273,28 @@
         return;
       }
 
-      // Facets
-      const facets={
-        categories: uniq(catalog.map(c=>c.category).filter(Boolean)).sort(),
-        imprints:   uniq(catalog.map(c=>c.imprint).filter(Boolean)).sort(),
-        tags:       uniq(catalog.flatMap(c=> (c.tags? c.tags.split(',').map(s=>s.trim()).filter(Boolean):[]) )).sort()
-      };
-
-      // Populate controls
-      const catEl=document.getElementById('cat'), impEl=document.getElementById('imp'), tagEl=document.getElementById('tag');
-      facets.categories.forEach(v=>catEl.append(new Option(v,v)));
-      facets.imprints.forEach(v=>impEl.append(new Option(v,v)));
-      facets.tags.forEach(v=>tagEl.append(new Option(v,v)));
-
-      const qEl=document.getElementById('q'), cardsEl=document.getElementById('cards'), countEl=document.getElementById('count');
-      function render(){
-        const q=norm(qEl.value), cat=norm(catEl.value), imp=norm(impEl.value), tag=norm(tagEl.value);
-        const list=catalog.filter(p=>{
-          if(cat && norm(p.category)!==cat) return false;
-          if(imp && norm(p.imprint)!==imp) return false;
-          if(tag){ const t=(p.tags||'').split(',').map(s=>norm(s.trim())).filter(Boolean); if(!t.includes(tag)) return false; }
-          if(q){ const hay=[p.name,p.category,p.vendor,p.vendorSku,p.imprint,p.tags].join(' ').toLowerCase(); if(!hay.includes(q)) return false; }
-          return true;
-        });
+      const cardsEl=document.getElementById('cards'), countEl=document.getElementById('count');
+      function renderCatalog(catSlug){
+        const list=catalog.filter(p=>!catSlug || slug(p.category)===catSlug);
         countEl.textContent = `${list.length} product${list.length===1?'':'s'} shown`;
-        cardsEl.innerHTML=''; list.forEach(p=>cardsEl.appendChild(card(p)));
+        cardsEl.innerHTML='';
+        const groups={};
+        list.forEach(p=>{const c=p.category||'Other';(groups[c]=groups[c]||[]).push(p);});
+        Object.keys(groups).sort().forEach(cat=>{
+          const h=document.createElement('h3'); h.textContent=cat; cardsEl.appendChild(h);
+          const grid=document.createElement('div'); grid.className='cards';
+          groups[cat].forEach(p=>grid.appendChild(card(p)));
+          cardsEl.appendChild(grid);
+        });
       }
 
       function card(p){
-        const wrap=document.createElement('div'); wrap.className='card';
+        const wrap=document.createElement('a'); wrap.className='card'; wrap.href=`#/p/${p.id}`;
         const t=document.createElement('div'); t.className='thumb';
         const img=document.createElement('img'); img.alt=p.name; img.src=p.thumb||'https://via.placeholder.com/800x600?text=No+Image'; t.appendChild(img);
 
         const meta=document.createElement('div'); meta.className='meta';
         const name=document.createElement('div'); name.className='name'; name.textContent=p.name;
-        const sub=document.createElement('div'); sub.className='sub';
-        const bits=[]; if(p.category) bits.push(p.category); if(p.imprint) bits.push(p.imprint); if(p.minQty) bits.push(`Min ${p.minQty}`);
-        sub.textContent = bits.join(' • ');
 
         const price=document.createElement('div'); price.className='price';
         if(p.minPrice!=null && p.maxPrice!=null){
@@ -324,33 +305,58 @@
           price.textContent = displayPrice('');
         }
 
-        const chips=document.createElement('div');
-        if(p.setup){ const c=document.createElement('span'); c.className='chip'; c.textContent=`Setup: $${p.setup}`; chips.appendChild(c); }
-        if(p.repeat){ const c=document.createElement('span'); c.className='chip'; c.textContent=`Repeat: $${p.repeat}`; chips.appendChild(c); }
-        if(p.lead){ const c=document.createElement('span'); c.className='chip'; c.textContent=`Lead: ${p.lead}d`; chips.appendChild(c); }
-
-        if(p.variants && p.variants.length){
-          const sizes=document.createElement('div'); sizes.className='sizes';
-          const dl=document.createElement('dl'); const dt=document.createElement('dt'); dt.textContent='Sizes & Prices'; dl.appendChild(dt);
-          p.variants.forEach(v=>{ const dd=document.createElement('dd'); dd.textContent=`${v.size||''} — ${displayPrice(v.price)}`; dl.appendChild(dd); });
-          sizes.appendChild(dl);
-          wrap.appendChild(sizes);
-        }
-
-        const actions=document.createElement('div'); actions.className='actions';
-        if(p.preview){ const a=document.createElement('a'); a.className='btn'; a.href=p.preview; a.target='_blank'; a.rel='noopener'; a.textContent='3D Preview'; actions.appendChild(a); }
-        if(p.vendorSku){ const s=document.createElement('span'); s.className='muted'; s.textContent=`SKU: ${p.vendorSku}`; actions.appendChild(s); }
-
-        meta.appendChild(name); if(sub.textContent) meta.appendChild(sub); if(price.textContent) meta.appendChild(price); if(chips.children.length) meta.appendChild(chips);
-        wrap.appendChild(t); wrap.appendChild(meta); wrap.appendChild(actions);
+        meta.appendChild(name); if(price.textContent) meta.appendChild(price);
+        wrap.appendChild(t); wrap.appendChild(meta);
         return wrap;
       }
 
-      qEl.addEventListener('input', render);
-      catEl.addEventListener('change', render);
-      impEl.addEventListener('change', render);
-      tagEl.addEventListener('change', render);
-      render();
+      window.renderCatalog=renderCatalog;
+
+      function showDetail(id){
+        const product=catalog.find(p=>p.id===id);
+        const mainEl=document.querySelector('main');
+        const detailEl=document.getElementById('detail');
+        if(!product){ location.hash=''; return; }
+        mainEl.style.display='none';
+        detailEl.style.display='block';
+        const c=document.getElementById('detail-content');
+        c.innerHTML='';
+        const back=document.createElement('a'); back.href='#'; back.className='btn'; back.textContent='← Back to Catalog'; c.appendChild(back);
+        const title=document.createElement('h2'); title.textContent=product.name; c.appendChild(title);
+        const layout=document.createElement('div'); layout.className='layout';
+        const imgCol=document.createElement('div');
+        const mainImg=document.createElement('img'); mainImg.src=product.thumb||'https://via.placeholder.com/800x600?text=No+Image'; imgCol.appendChild(mainImg);
+        const gallery=(product.gallery||'').split(',').map(s=>s.trim()).filter(Boolean);
+        if(gallery.length){
+          const g=document.createElement('div'); g.className='gallery';
+          gallery.forEach(u=>{const im=document.createElement('img'); im.src=u; g.appendChild(im);});
+          imgCol.appendChild(g);
+        }
+        layout.appendChild(imgCol);
+        const info=document.createElement('div');
+        if(product.description){ const pDesc=document.createElement('p'); pDesc.textContent=product.description; info.appendChild(pDesc); }
+        if(product.preview){ const iframe=document.createElement('iframe'); iframe.src=product.preview; iframe.loading='lazy'; iframe.style.width='100%'; iframe.style.height='480px'; iframe.style.border='0'; info.appendChild(iframe); }
+        if(product.variants && product.variants.length){ const sizes=document.createElement('div'); sizes.className='sizes'; const dl=document.createElement('dl'); const dt=document.createElement('dt'); dt.textContent='Sizes & Prices'; dl.appendChild(dt); product.variants.forEach(v=>{ const dd=document.createElement('dd'); dd.textContent=`${v.size||''} — ${displayPrice(v.price)}`; dl.appendChild(dd); }); sizes.appendChild(dl); info.appendChild(sizes); }
+        layout.appendChild(info);
+        c.appendChild(layout);
+      }
+
+      function handleRoute(){
+        const hash=location.hash;
+        const mainEl=document.querySelector('main');
+        const detailEl=document.getElementById('detail');
+        if(hash.startsWith('#/p/')){
+          showDetail(hash.slice(4));
+        } else {
+          detailEl.style.display='none';
+          mainEl.style.display='block';
+          const m=hash.match(/^#\/c\/(.+)$/);
+          renderCatalog(m?m[1]:'');
+        }
+      }
+
+      window.addEventListener('hashchange', handleRoute);
+      handleRoute();
     }
 
     main().catch(err=>{


### PR DESCRIPTION
## Summary
- group catalog items by dynamic category headers
- simplify product cards to show only name and price range
- implement hash-based product detail page with description, images, sizes and 3D preview

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68bf4a0cf0bc832eb5313da66c090578