### PR TITLE
fix: resolve detail drawer merge and restore variant table styles

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -59,6 +59,11 @@ a:hover{text-decoration:underline}
 .detail .imprint,.detail .tags{margin-top:8px;font-size:14px;color:var(--muted)}
 .detail .tags span{display:inline-block;background:#f1f5f9;color:#475569;border-radius:12px;padding:2px 8px;margin:0 4px 4px 0;font-size:12px}
 
+/* Variant pricing table styles */
+.detail .variant-table{width:100%;border-collapse:collapse;margin-top:16px;font-size:14px}
+.detail .variant-table th,.detail .variant-table td{border:1px solid #ddd;padding:8px;text-align:left}
+.detail .variant-table th{background:#f9fafb;font-family:Montserrat,system-ui;font-weight:700}
+
 /* Footer */
 footer{border-top:1px solid #eee;background:#fff}
 footer .wrap{max-width:var(--wrap);margin:0 auto;padding:20px var(--pad);display:flex;gap:24px;align-items:center;justify-content:space-between;flex-wrap:wrap}


### PR DESCRIPTION
## Summary
- remove leftover merge markers and consolidate detail drawer CSS
- restore variant pricing table styles after drawer rules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c05bcf42b4832ea90afacadee8dd04