### PR TITLE
Add preview link to product details

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,7 @@
         <p id="detail-desc"></p>
         <div id="detail-imp" class="imprint"></div>
         <div id="detail-tags" class="tags"></div>
+        <a id="detail-preview" class="preview-link" target="_blank"></a>
         <div id="detail-variants"></div>
       </div>
     </div>

--- a/scripts/catalog.js
+++ b/scripts/catalog.js
@@ -55,7 +55,7 @@ const PRODUCT_COLS={
   slug:      ['Slug','Product ID','product_id','slug','ID','id'],
   name:      ['Product Name','Name','Item Name','title'],
   category:  ['Category','Categories','category'],
-  preview:   ['Preview Link','3D Preview URL','Preview URL','model_3d_url','Model 3D URL'],
+  preview:   ['Preview','preview','Preview Link','Preview URL','3D Preview URL','model_3d_url','Model 3D URL'],
   thumb:     ['Thumbnail URL','Image','Image URL','Primary Image','primary_image_url','image_url','primary image'],
   description:['Description','Product Description','description'],
   gallery:   ['Gallery URLs','Gallery','gallery_urls','gallery'],
@@ -209,6 +209,15 @@ async function main(){
       span.textContent=t;
       tagsEl.appendChild(span);
     });
+
+    const previewEl=document.getElementById('detail-preview');
+    if(product.preview){
+      previewEl.href=product.preview;
+      previewEl.textContent='Preview';
+      previewEl.style.display='inline-block';
+    } else {
+      previewEl.style.display='none';
+    }
 
     const priceEl=document.getElementById('detail-price');
     if(product.minPrice!=null && product.maxPrice!=null){

--- a/styles/main.css
+++ b/styles/main.css
@@ -59,6 +59,9 @@ a:hover{text-decoration:underline}
 .detail .imprint,.detail .tags{margin-top:8px;font-size:14px;color:var(--muted)}
 .detail .tags span{display:inline-block;background:#f1f5f9;color:#475569;border-radius:12px;padding:2px 8px;margin:0 4px 4px 0;font-size:12px}
 
+.detail .preview-link{display:inline-block;margin-top:12px;padding:10px 16px;background:var(--brand);color:#fff;border-radius:var(--radius);font-family:Montserrat,system-ui;font-weight:700;text-decoration:none}
+.detail .preview-link:hover{background:var(--brand-dark)}
+
 /* Variant pricing table styles */
 .detail .variant-table{width:100%;border-collapse:collapse;margin-top:16px;font-size:14px}
 .detail .variant-table th,.detail .variant-table td{border:1px solid #ddd;padding:8px;text-align:left}


### PR DESCRIPTION
## Summary
- expose product preview URL in detail drawer with new link
- style preview link button
- support new preview column aliases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c0637d9d94832e86be6c77382a899a