### PR TITLE
Handle pipe-separated galleries

### DIFF
--- a/scripts/catalog.js
+++ b/scripts/catalog.js
@@ -234,7 +234,7 @@ async function main(){
 
     const hero=document.getElementById('detail-hero');
     hero.innerHTML='';
-    const gallery=(product.gallery||'').split(',').map(s=>s.trim()).filter(Boolean);
+    const gallery=(product.gallery||'').split(/[|,]/).map(s=>s.trim()).filter(Boolean);
     const heroImg=document.createElement('img');
     heroImg.src=gallery[0]||product.thumb||'https://via.placeholder.com/800x600?text=No+Image';
     hero.appendChild(heroImg);


### PR DESCRIPTION
## Summary
- ensure `showDetail` loads thumbnails for gallery URLs separated by either commas or pipes

## Testing
- `npm test`
- `node -e "['a,b,c','a|b|c','a,b|c'].forEach(str=>{const gallery=(str||'').split(/[|,]/).map(s=>s.trim()).filter(Boolean);console.log(str,'=>',gallery);})"`
- `npm start` and `curl -I localhost:3000/index.html`


------
https://chatgpt.com/codex/tasks/task_b_68c0650125cc832e9df4d9f102442cc8