### PR TITLE
Enable hero image swap on thumbnail click

### DIFF
--- a/scripts/catalog.js
+++ b/scripts/catalog.js
@@ -243,7 +243,15 @@ async function main(){
     thumbSlots.forEach((slot,i)=>{
       slot.innerHTML='';
       const url=gallery[i]||null;
-      if(url){ const im=document.createElement('img'); im.src=url; slot.appendChild(im); }
+      // Clear any existing click handler so they don't accumulate
+      slot.onclick=null;
+      if(url){
+        const im=document.createElement('img');
+        im.src=url;
+        slot.appendChild(im);
+        // Show the clicked thumbnail in the hero area
+        slot.onclick=()=>{ heroImg.src=url; };
+      }
     });
 
     const varEl=document.getElementById('detail-variants');


### PR DESCRIPTION
## Summary
- update product detail thumbnails to swap the hero image when clicked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c06bd5ac94832eaa78cb348a47ef96