### PR TITLE
Generate thumbnails dynamically in product detail

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,12 +42,7 @@
       <button id="detail-close" class="close" aria-label="Close">×</button>
       <div class="media">
         <div id="detail-hero" class="hero"></div>
-        <div class="thumbs">
-          <div class="thumb"></div>
-          <div class="thumb"></div>
-          <div class="thumb"></div>
-          <div class="thumb"></div>
-        </div>
+        <div class="thumbs"></div>
       </div>
       <div class="info">
         <h2 id="detail-title"></h2>

--- a/scripts/catalog.js
+++ b/scripts/catalog.js
@@ -258,20 +258,16 @@ async function main(){
     const heroImg=document.createElement('img');
     heroImg.src=gallery[0]||product.thumb||'https://via.placeholder.com/800x600?text=No+Image';
     hero.appendChild(heroImg);
-
-    const thumbSlots=detailEl.querySelectorAll('.thumb');
-    thumbSlots.forEach((slot,i)=>{
-      slot.innerHTML='';
-      const url=gallery[i]||null;
-      // Clear any existing click handler so they don't accumulate
-      slot.onclick=null;
-      if(url){
-        const im=document.createElement('img');
-        im.src=url;
-        slot.appendChild(im);
-        // Show the clicked thumbnail in the hero area
-        slot.onclick=()=>{ heroImg.src=url; };
-      }
+    const thumbsWrap = detailEl.querySelector('.thumbs');
+    thumbsWrap.innerHTML = '';
+    gallery.forEach(url => {
+      const slot = document.createElement('div');
+      slot.className = 'thumb';
+      const im = document.createElement('img');
+      im.src = url;
+      slot.appendChild(im);
+      slot.onclick = () => { heroImg.src = url; };
+      thumbsWrap.appendChild(slot);
     });
 
     const varEl=document.getElementById('detail-variants');

--- a/styles/main.css
+++ b/styles/main.css
@@ -62,7 +62,7 @@ a:hover{text-decoration:underline}
 .detail .close{position:absolute;top:8px;right:12px;border:none;background:none;font-size:28px;line-height:1;cursor:pointer}
 .detail .media{padding:20px}
 .detail .hero img{width:100%;height:auto;max-height:400px;object-fit:contain;border-radius:var(--radius)}
-.detail .thumbs{display:flex;gap:8px;margin-top:8px}
+.detail .thumbs{display:flex;gap:8px;margin-top:8px;overflow-x:auto}
 .detail .thumbs .thumb{flex:0 0 80px;background:#f5f5f5;border:1px solid #eee;border-radius:var(--radius);height:80px;width:80px;display:flex;align-items:center;justify-content:center;overflow:hidden}
 .detail .thumbs .thumb img{width:100%;height:100%;object-fit:cover}
 .detail .info{padding:0 20px}


### PR DESCRIPTION
## Summary
- Remove hardcoded thumbnail slots from the detail drawer
- Build thumbnail elements dynamically from the product gallery
- Allow thumbnail strip to scroll when more images are present

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c1870b9e5c832eb9d3958a8aa2545d