### PR TITLE
Use trophy emoji as favicon

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Page not found • Rocket Catalog</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%20100%20100'%3E%3Ctext%20y%3D'.9em'%20font-size%3D'90'%3E%F0%9F%8F%86%3C%2Ftext%3E%3C%2Fsvg%3E">
   <link rel="stylesheet" href="styles/main.css">
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Rocket Catalog</title>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%20100%20100'%3E%3Ctext%20y%3D'.9em'%20font-size%3D'90'%3E%F0%9F%8F%86%3C%2Ftext%3E%3C%2Fsvg%3E">
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles/main.css">
 </head>

--- a/preview.html
+++ b/preview.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Rocket Catalog Theme Preview</title>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%20100%20100'%3E%3Ctext%20y%3D'.9em'%20font-size%3D'90'%3E%F0%9F%8F%86%3C%2Ftext%3E%3C%2Fsvg%3E">
   <link rel="stylesheet" href="/Rocket-Catalog/theme/assets/default-main.css" />
   <link rel="stylesheet" href="/Rocket-Catalog/theme/assets/custom-main.css" />
 </head>

--- a/theme/layout/theme.liquid
+++ b/theme/layout/theme.liquid
@@ -4,7 +4,7 @@
 <head>
   {% seo_tags %}
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" type="image/png" href="{{ 'favicon.png' | asset_url }}">
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%20100%20100'%3E%3Ctext%20y%3D'.9em'%20font-size%3D'90'%3E%F0%9F%8F%86%3C%2Ftext%3E%3C%2Fsvg%3E">
 
   {{ 'default-main.css' | asset_url | stylesheet_tag }}
   {{ 'custom-main.css' | asset_url | stylesheet_tag }}


### PR DESCRIPTION
## Summary
- Display 🏆 emoji as site favicon by inlining SVG data URL
- Apply trophy favicon to standalone pages and theme layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c42a0e2590832e93549803a62c16f0