### PR TITLE
Remove tagline from showroom cards

### DIFF
--- a/scripts/showroom.js
+++ b/scripts/showroom.js
@@ -557,13 +557,6 @@
       name.textContent = product.name;
       body.appendChild(name);
 
-      if(product.tagline){
-        const blurb = document.createElement('p');
-        blurb.className = 'showroom-card__tagline';
-        blurb.textContent = product.tagline;
-        body.appendChild(blurb);
-      }
-
       const price = document.createElement('div');
       price.className = 'showroom-card__price';
       price.textContent = priceSummary(product);


### PR DESCRIPTION
## Summary
- stop rendering tagline text inside showroom grid cards so only the name and price appear

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d2d89da1d0832ebd41db16d551d66d